### PR TITLE
Modifications for more robustness

### DIFF
--- a/Safari/Show|Create-Tab.applescript
+++ b/Safari/Show|Create-Tab.applescript
@@ -5,6 +5,7 @@ set theURL to "https://play.hbonow.com/series"
 
 --
 tell application "Safari"
+	activate
 	set winList to every window
 	set urlFound to false
 	repeat with i from 1 to (count of winList)

--- a/Safari/Show|Create-Tab.applescript
+++ b/Safari/Show|Create-Tab.applescript
@@ -22,6 +22,9 @@ tell application "Safari"
 	end repeat
 	
 	if urlFound is false then
+		if winList is {} then
+			make new document
+		end if
 		tell front window
 			set current tab to make new tab at end of tabs with properties {URL:theURL}
 		end tell


### PR DESCRIPTION
I modified the Safari/Show|Create-Tab.applescript file to make it more robust, handling the situation where there is no open Safari window. The existing script fails if Safari is not running, or is running but has no window open.

I also added an activate just below the `tell application "Safari"` line in case Safari wasn't already launched. This helps in bringing up a fresh window in that case.

I tested this script with Safari 15.2 on macOS 12.1 Monterey.